### PR TITLE
feat: implement comprehensive rate limiting system with 20 requests/hour

### DIFF
--- a/functions/src/middleware/rateLimit.ts
+++ b/functions/src/middleware/rateLimit.ts
@@ -101,6 +101,9 @@ export function rateLimitByUser(limit: number, windowMs: number) {
     const uid = user.uid
     const route = req.path || 'unknown'
     const key = `user:${uid}:route:${route}:win:${windowMs}`
+    console.info(
+      `Rate limiting check for user ${uid}, route: "${route}", key: "${key}"`
+    )
     const allowed = await checkAndIncrementRateLimit(key, limit, windowMs)
     if (!allowed) {
       return errorResponse(
@@ -177,4 +180,69 @@ export async function getUserRateLimitStatus(
 }> {
   const key = `user:${uid}:route:${route}:win:${windowMs}`
   return await getRateLimitStatus(key, limit, windowMs)
+}
+
+// Function to clear all rate limits for a specific user
+export async function clearUserRateLimits(uid: string): Promise<void> {
+  try {
+    console.info(`Attempting to clear rate limits for user: ${uid}`)
+
+    // Clear rate limits for the parlay generation route
+    // Try different possible route variations that might be used
+    const routes = [
+      '/parlays/generate',
+      'parlays/generate',
+      '/parlays/generate/',
+      'parlays/generate/',
+    ]
+    const windowMs = 60 * 60 * 1000 // 1 hour window
+
+    const batch = db.batch()
+    let deleteCount = 0
+
+    for (const route of routes) {
+      const key = `user:${uid}:route:${route}:win:${windowMs}`
+      const ref = rateLimitDocRef(key)
+      const doc = await ref.get()
+
+      if (doc.exists) {
+        console.info(`Found rate limit document for route: ${route}`)
+        batch.delete(ref)
+        deleteCount++
+      } else {
+        console.info(`No rate limit document found for route: ${route}`)
+      }
+    }
+
+    if (deleteCount > 0) {
+      await batch.commit()
+      console.info(
+        `Successfully cleared ${deleteCount} rate limit records for user ${uid}`
+      )
+    } else {
+      console.info(
+        `No rate limit records found for user ${uid} with any of the tried routes`
+      )
+    }
+  } catch (error) {
+    console.error('Error clearing user rate limits:', error)
+    throw error
+  }
+}
+
+// Function to clear rate limits for a specific user and route
+export async function clearUserRateLimitForRoute(
+  uid: string,
+  route: string,
+  windowMs: number
+): Promise<void> {
+  try {
+    const key = `user:${uid}:route:${route}:win:${windowMs}`
+    const ref = rateLimitDocRef(key)
+    await ref.delete()
+    console.info(`Cleared rate limit for user ${uid} on route ${route}`)
+  } catch (error) {
+    console.error('Error clearing user rate limit for route:', error)
+    throw error
+  }
 }

--- a/functions/src/middleware/rateLimit.ts
+++ b/functions/src/middleware/rateLimit.ts
@@ -101,9 +101,6 @@ export function rateLimitByUser(limit: number, windowMs: number) {
     const uid = user.uid
     const route = req.path || 'unknown'
     const key = `user:${uid}:route:${route}:win:${windowMs}`
-    console.info(
-      `Rate limiting check for user ${uid}, route: "${route}", key: "${key}"`
-    )
     const allowed = await checkAndIncrementRateLimit(key, limit, windowMs)
     if (!allowed) {
       return errorResponse(
@@ -184,49 +181,32 @@ export async function getUserRateLimitStatus(
 
 // Function to clear all rate limits for a specific user
 export async function clearUserRateLimits(uid: string): Promise<void> {
-  try {
-    console.info(`Attempting to clear rate limits for user: ${uid}`)
+  // Clear rate limits for the parlay generation route
+  // Try different possible route variations that might be used
+  const routes = [
+    '/parlays/generate',
+    'parlays/generate',
+    '/parlays/generate/',
+    'parlays/generate/',
+  ]
+  const windowMs = 60 * 60 * 1000 // 1 hour window
 
-    // Clear rate limits for the parlay generation route
-    // Try different possible route variations that might be used
-    const routes = [
-      '/parlays/generate',
-      'parlays/generate',
-      '/parlays/generate/',
-      'parlays/generate/',
-    ]
-    const windowMs = 60 * 60 * 1000 // 1 hour window
+  const batch = db.batch()
+  let deleteCount = 0
 
-    const batch = db.batch()
-    let deleteCount = 0
+  for (const route of routes) {
+    const key = `user:${uid}:route:${route}:win:${windowMs}`
+    const ref = rateLimitDocRef(key)
+    const doc = await ref.get()
 
-    for (const route of routes) {
-      const key = `user:${uid}:route:${route}:win:${windowMs}`
-      const ref = rateLimitDocRef(key)
-      const doc = await ref.get()
-
-      if (doc.exists) {
-        console.info(`Found rate limit document for route: ${route}`)
-        batch.delete(ref)
-        deleteCount++
-      } else {
-        console.info(`No rate limit document found for route: ${route}`)
-      }
+    if (doc.exists) {
+      batch.delete(ref)
+      deleteCount++
     }
+  }
 
-    if (deleteCount > 0) {
-      await batch.commit()
-      console.info(
-        `Successfully cleared ${deleteCount} rate limit records for user ${uid}`
-      )
-    } else {
-      console.info(
-        `No rate limit records found for user ${uid} with any of the tried routes`
-      )
-    }
-  } catch (error) {
-    console.error('Error clearing user rate limits:', error)
-    throw error
+  if (deleteCount > 0) {
+    await batch.commit()
   }
 }
 
@@ -236,13 +216,7 @@ export async function clearUserRateLimitForRoute(
   route: string,
   windowMs: number
 ): Promise<void> {
-  try {
-    const key = `user:${uid}:route:${route}:win:${windowMs}`
-    const ref = rateLimitDocRef(key)
-    await ref.delete()
-    console.info(`Cleared rate limit for user ${uid} on route ${route}`)
-  } catch (error) {
-    console.error('Error clearing user rate limit for route:', error)
-    throw error
-  }
+  const key = `user:${uid}:route:${route}:win:${windowMs}`
+  const ref = rateLimitDocRef(key)
+  await ref.delete()
 }

--- a/functions/src/middleware/rateLimit.ts
+++ b/functions/src/middleware/rateLimit.ts
@@ -114,3 +114,67 @@ export function rateLimitByUser(limit: number, windowMs: number) {
     next()
   }
 }
+
+export async function getRateLimitStatus(
+  key: string,
+  limit: number,
+  windowMs: number
+): Promise<{
+  remaining: number
+  total: number
+  resetTime: Date
+  currentCount: number
+}> {
+  const now = Date.now()
+  const ref = rateLimitDocRef(key)
+  const snap = await ref.get()
+
+  if (!snap.exists) {
+    return {
+      remaining: limit,
+      total: limit,
+      resetTime: new Date(now + windowMs),
+      currentCount: 0,
+    }
+  }
+
+  const record = snap.data() as RateLimitRecord
+  const windowStart = record.windowStart
+  const currentCount = record.count
+
+  // Check if window has expired
+  if (now - windowStart >= windowMs) {
+    return {
+      remaining: limit,
+      total: limit,
+      resetTime: new Date(now + windowMs),
+      currentCount: 0,
+    }
+  }
+
+  const remaining = Math.max(0, limit - currentCount)
+  const resetTime = new Date(windowStart + windowMs)
+
+  return {
+    remaining,
+    total: limit,
+    resetTime,
+    currentCount,
+  }
+}
+
+// Function to get rate limit status for a user
+export async function getUserRateLimitStatus(
+  uid: string,
+  route: string,
+  limit: number,
+  windowMs: number
+): Promise<{
+  remaining: number
+  total: number
+  resetTime: Date
+  currentCount: number
+}> {
+  const key = `user:${uid}:route:${route}:win:${windowMs}`
+  return await getRateLimitStatus(key, limit, windowMs)
+}

--- a/functions/src/providers/pfr/utils.ts
+++ b/functions/src/providers/pfr/utils.ts
@@ -47,7 +47,7 @@ export function getPFRCodeFromTeamName(teamName: string): string | null {
 /**
  * Get team abbreviation from team name for logo URLs
  */
-function getTeamAbbreviation(teamName: string): string {
+function getTeamAbbreviation(teamName: string): string | null {
   const teamNameToAbbreviation: { [key: string]: string } = {
     'Dallas Cowboys': 'DAL',
     'San Francisco 49ers': 'SF',
@@ -83,14 +83,20 @@ function getTeamAbbreviation(teamName: string): string {
     'Washington Commanders': 'WAS',
   }
 
-  return teamNameToAbbreviation[teamName] || teamName.toUpperCase().slice(0, 3)
+  const fallback = teamName.toUpperCase().slice(0, 3)
+  return (
+    teamNameToAbbreviation[teamName] || (fallback.length >= 2 ? fallback : null)
+  )
 }
 
 /**
  * Generate logo URL using Fantasy Nerds API
  */
-function getTeamLogoUrl(teamName: string): string {
+function getTeamLogoUrl(teamName: string): string | null {
   const abbreviation = getTeamAbbreviation(teamName)
+  if (!abbreviation) {
+    return null
+  }
   return `https://www.fantasynerds.com/images/nfl/teams/${abbreviation}.gif`
 }
 
@@ -102,15 +108,16 @@ export function createPFRTeamFromName(teamName: string): PFRTeam {
     getPFRCodeFromTeamName(teamName) ||
     teamName.toLowerCase().replace(/\s+/g, '')
   const abbreviation = getTeamAbbreviation(teamName)
+  const logoUrl = getTeamLogoUrl(teamName)
 
   return {
     id: pfrCode,
     name: teamName,
     displayName: teamName,
-    abbreviation,
+    abbreviation: abbreviation || 'UNK',
     color: '000000', // Default color - could be enhanced with actual team colors
     alternateColor: '000000',
-    logo: getTeamLogoUrl(teamName),
+    logo: logoUrl || '',
   }
 }
 

--- a/functions/src/routes/protected/handlers.ts
+++ b/functions/src/routes/protected/handlers.ts
@@ -1,5 +1,8 @@
 import express from 'express'
-import { getUserRateLimitStatus } from '../../middleware/rateLimit'
+import {
+  clearUserRateLimits,
+  getUserRateLimitStatus,
+} from '../../middleware/rateLimit'
 import { fetchPFRSeasonSchedule } from '../../providers/pfr'
 import { fetchPFRTeamDataForGame } from '../../providers/pfr/teamStatsScraper'
 import { generateParlayWithAI } from '../../service/ai'
@@ -327,6 +330,44 @@ export const generateParlayHandler = async (
       500,
       'internal_error',
       'Failed to generate parlay',
+      correlationId
+    )
+  }
+}
+
+export const clearUserRateLimitsHandler = async (
+  req: express.Request,
+  res: express.Response
+) => {
+  const authReq = req as AuthenticatedRequest
+  const correlationId = authReq.correlationId
+
+  try {
+    const user = authReq.user
+    if (!user) {
+      return errorResponse(
+        res,
+        401,
+        'unauthorized',
+        'User not authenticated',
+        correlationId
+      )
+    }
+
+    await clearUserRateLimits(user.uid)
+
+    res.json({
+      success: true,
+      message: 'Rate limits cleared successfully',
+      userId: user.uid,
+    })
+  } catch (error) {
+    console.error('Error clearing user rate limits:', error)
+    return errorResponse(
+      res,
+      500,
+      'internal_error',
+      'Failed to clear rate limits',
       correlationId
     )
   }

--- a/functions/src/routes/protected/handlers.ts
+++ b/functions/src/routes/protected/handlers.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import { getUserRateLimitStatus } from '../../middleware/rateLimit'
 import { fetchPFRSeasonSchedule } from '../../providers/pfr'
 import { fetchPFRTeamDataForGame } from '../../providers/pfr/teamStatsScraper'
 import { generateParlayWithAI } from '../../service/ai'
@@ -227,6 +228,21 @@ export const generateParlayHandler = async (
     const homeRoster = null
     const awayRoster = null
 
+    // Get current rate limit status for the user
+    const rateLimitStatus = user
+      ? await getUserRateLimitStatus(
+          user.uid,
+          '/parlays/generate',
+          20,
+          60 * 60_000
+        )
+      : {
+          remaining: 20,
+          total: 20,
+          resetTime: new Date(Date.now() + 60 * 60_000),
+          currentCount: 0,
+        }
+
     const response: GenerateParlayResponse = {
       parlay: {
         parlayId: `pl_${Math.random().toString(36).slice(2, 10)}`,
@@ -284,6 +300,12 @@ export const generateParlayHandler = async (
         },
         venue: game.venue,
         leaders: game.leaders,
+      },
+      rateLimitInfo: {
+        remaining: rateLimitStatus.remaining,
+        total: rateLimitStatus.total,
+        resetTime: rateLimitStatus.resetTime.toISOString(),
+        currentCount: rateLimitStatus.currentCount,
       },
     }
 

--- a/functions/src/routes/protected/index.ts
+++ b/functions/src/routes/protected/index.ts
@@ -8,6 +8,6 @@ export const protectedRouter = express.Router()
 protectedRouter.post(
   '/parlays/generate',
   verifyAuth,
-  rateLimitByUser(10, 30 * 60_000),
+  rateLimitByUser(20, 60 * 60_000), // 20 requests per hour (60 minutes)
   generateParlayHandler
 )

--- a/functions/src/routes/protected/index.ts
+++ b/functions/src/routes/protected/index.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import { verifyAuth } from '../../middleware/auth'
 import { rateLimitByUser } from '../../middleware/rateLimit'
-import { generateParlayHandler } from './handlers'
+import { clearUserRateLimitsHandler, generateParlayHandler } from './handlers'
 
 export const protectedRouter = express.Router()
 
@@ -10,4 +10,10 @@ protectedRouter.post(
   verifyAuth,
   rateLimitByUser(20, 60 * 60_000), // 20 requests per hour (60 minutes)
   generateParlayHandler
+)
+
+protectedRouter.post(
+  '/rate-limits/clear',
+  verifyAuth,
+  clearUserRateLimitsHandler
 )

--- a/functions/src/routes/protected/schema.ts
+++ b/functions/src/routes/protected/schema.ts
@@ -133,4 +133,10 @@ export type GenerateParlayResponse = {
       receiving?: { name: string; stats: string; value: number }
     }
   }
+  rateLimitInfo: {
+    remaining: number
+    total: number
+    resetTime: string // ISO string format
+    currentCount: number
+  }
 }

--- a/functions/src/service/ai/openai.ts
+++ b/functions/src/service/ai/openai.ts
@@ -1,7 +1,9 @@
 import OpenAI from 'openai'
 
 export function getOpenAI(): OpenAI | null {
+  // Try environment variable first (for local development)
   const key = process.env.OPENAI_API_KEY
+
   if (!key || key.length === 0) {
     return null
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "node start-dev.js",
     "dev:functions": "firebase emulators:start --only functions",
     "dev:frontend": "vite --host",
+    "kill:all": "node scripts/kill-all.js",
     "build": "tsc && vite build",
     "lint": "eslint src --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint src --ext .ts,.tsx --fix --report-unused-disable-directives --max-warnings 0",

--- a/scripts/kill-all.js
+++ b/scripts/kill-all.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { exec } from 'child_process'
+import { promisify } from 'util'
+
+const execAsync = promisify(exec)
+
+const isWindows = process.platform === 'win32'
+
+const processesToKill = [
+  'firebase',
+  'vite',
+  'concurrently',
+  'node', // for any node processes running dev scripts
+]
+
+async function killProcesses() {
+  console.log('🔪 Killing all development processes...\n')
+
+  for (const processName of processesToKill) {
+    try {
+      if (isWindows) {
+        // Windows: Use taskkill
+        const { stdout, stderr } = await execAsync(
+          `taskkill /f /im "${processName}.exe" /t 2>nul || echo "No ${processName} processes found"`
+        )
+        if (stdout && !stdout.includes('No') && !stdout.includes('not found')) {
+          console.log(`✅ Killed ${processName} processes`)
+        }
+      } else {
+        // macOS/Linux: Use pkill
+        const { stdout, stderr } = await execAsync(
+          `pkill -f "${processName}" 2>/dev/null || echo "No ${processName} processes found"`
+        )
+        if (stdout && !stdout.includes('No')) {
+          console.log(`✅ Killed ${processName} processes`)
+        }
+      }
+    } catch (error) {
+      // Ignore errors - process might not be running
+      console.log(`ℹ️  No ${processName} processes found`)
+    }
+  }
+
+  console.log('\n🎉 All development processes killed!')
+  console.log('💡 You can now run "npm run dev" to start fresh')
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', () => {
+  console.log('\n👋 Goodbye!')
+  process.exit(0)
+})
+
+process.on('SIGTERM', () => {
+  console.log('\n👋 Goodbye!')
+  process.exit(0)
+})
+
+killProcesses().catch(console.error)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,6 +199,7 @@ function AppContent() {
             onWeekChange={handleWeekChange}
             availableWeeks={availableWeeks}
             weekLoading={weekLoading || gamesLoading}
+            parlayError={parlayError}
           />
 
           {/* Stats panel for selected game */}
@@ -216,16 +217,6 @@ function AppContent() {
                 />
               )
             })()}
-
-          {/* Show any parlay errors (excluding rate limit errors which are handled in GameSelector) */}
-          {parlayError &&
-            !parlayError.message?.includes('Rate limit exceeded') && (
-              <Box sx={{ mb: 2 }}>
-                <Typography color="error">
-                  Error: {parlayError.message}
-                </Typography>
-              </Box>
-            )}
 
           {/* ParlayDisplay gets parlay from store */}
           <ParlayDisplay parlay={parlay || undefined} loading={parlayLoading} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,14 +217,15 @@ function AppContent() {
               )
             })()}
 
-          {/* Show any parlay errors */}
-          {parlayError && (
-            <Box sx={{ mb: 2 }}>
-              <Typography color="error">
-                Error: {parlayError.message}
-              </Typography>
-            </Box>
-          )}
+          {/* Show any parlay errors (excluding rate limit errors which are handled in GameSelector) */}
+          {parlayError &&
+            !parlayError.message?.includes('Rate limit exceeded') && (
+              <Box sx={{ mb: 2 }}>
+                <Typography color="error">
+                  Error: {parlayError.message}
+                </Typography>
+              </Box>
+            )}
 
           {/* ParlayDisplay gets parlay from store */}
           <ParlayDisplay parlay={parlay || undefined} loading={parlayLoading} />

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -1,0 +1,102 @@
+import { AccessTime as AccessTimeIcon } from '@mui/icons-material'
+import { Alert, Box, Chip, Typography } from '@mui/material'
+import React from 'react'
+
+export type ErrorBannerType =
+  | 'rate_limit_reached'
+  | 'rate_limit_warning'
+  | 'error'
+  | 'info'
+  | 'success'
+
+interface ErrorBannerProps {
+  type: ErrorBannerType
+  title?: string
+  message: string
+  countdown?: string
+  icon?: React.ReactNode
+  show?: boolean
+}
+
+/**
+ * Generic Error Banner Component
+ * Shows various types of error and status messages with appropriate styling
+ */
+export const ErrorBanner: React.FC<ErrorBannerProps> = ({
+  type,
+  title,
+  message,
+  countdown,
+  icon,
+  show = true,
+}) => {
+  if (!show) {
+    return null
+  }
+
+  const getSeverity = () => {
+    switch (type) {
+      case 'rate_limit_reached':
+        return 'warning'
+      case 'rate_limit_warning':
+        return 'info'
+      case 'error':
+        return 'error'
+      case 'info':
+        return 'info'
+      case 'success':
+        return 'success'
+      default:
+        return 'info'
+    }
+  }
+
+  const getDefaultIcon = () => {
+    switch (type) {
+      case 'rate_limit_reached':
+      case 'rate_limit_warning':
+        return <AccessTimeIcon />
+      default:
+        return undefined
+    }
+  }
+
+  const severity = getSeverity()
+  const displayIcon = icon || getDefaultIcon()
+
+  return (
+    <Alert
+      severity={severity}
+      icon={displayIcon}
+      sx={{
+        mb: 2,
+        '& .MuiAlert-message': {
+          width: '100%',
+        },
+      }}
+    >
+      <Box sx={{ textAlign: 'center' }}>
+        {title && (
+          <Typography variant="body2" sx={{ fontWeight: 500, mb: 1 }}>
+            {title}
+          </Typography>
+        )}
+        <Typography variant="body2" color="text.secondary">
+          {message}
+        </Typography>
+        {countdown && (
+          <Box sx={{ mt: 1 }}>
+            <Chip
+              label={countdown}
+              size="small"
+              color="primary"
+              variant="outlined"
+            />
+          </Box>
+        )}
+      </Box>
+    </Alert>
+  )
+}
+
+export default ErrorBanner

--- a/src/components/GameSelector.tsx
+++ b/src/components/GameSelector.tsx
@@ -1,4 +1,7 @@
-import { Casino as CasinoIcon } from '@mui/icons-material'
+import {
+  AccessTime as AccessTimeIcon,
+  Casino as CasinoIcon,
+} from '@mui/icons-material'
 import {
   Box,
   Button,
@@ -15,8 +18,10 @@ import { SelectChangeEvent } from '@mui/material/Select'
 import React from 'react'
 import { useParlayGenerator } from '../hooks/useParlayGenerator'
 import { usePFRSchedule } from '../hooks/usePFRSchedule'
+import { useRateLimit } from '../hooks/useRateLimit'
 import useParlayStore from '../store/parlayStore'
 import TeamLogo from './display/TeamLogo'
+import ErrorBanner from './ErrorBanner'
 import WeekSelector from './WeekSelector'
 
 interface GameSelectorProps {
@@ -39,6 +44,10 @@ const GameSelector: React.FC<GameSelectorProps> = ({
 }) => {
   // Use PFR schedule hook and filter by current week
   const { data: allGames, isLoading: loading, error } = usePFRSchedule()
+
+  // Rate limiting hook
+  const { rateLimitInfo, isAtLimit, isNearLimit, getTimeUntilReset } =
+    useRateLimit()
 
   const games = allGames?.filter(game => game.week === currentWeek) || []
   const selectedGame = useParlayStore(state => state.selectedGame)
@@ -301,16 +310,38 @@ const GameSelector: React.FC<GameSelectorProps> = ({
                   </Typography>
                 </Box>
 
+                {/* Rate limit status */}
+                {rateLimitInfo && (
+                  <>
+                    {isAtLimit() && (
+                      <ErrorBanner
+                        type="rate_limit_reached"
+                        title="Rate limit reached"
+                        message={`You've used all ${rateLimitInfo.total} parlay generations for this hour.`}
+                        countdown={getTimeUntilReset()}
+                      />
+                    )}
+                    {isNearLimit() && !isAtLimit() && (
+                      <ErrorBanner
+                        type="rate_limit_warning"
+                        message="You're approaching your hourly limit"
+                        countdown={getTimeUntilReset()}
+                      />
+                    )}
+                  </>
+                )}
+
                 <Button
                   variant="contained"
                   size="large"
-                  startIcon={<CasinoIcon />}
+                  startIcon={isAtLimit() ? <AccessTimeIcon /> : <CasinoIcon />}
                   onClick={onGenerateParlay}
-                  disabled={!canGenerate || loading}
+                  disabled={!canGenerate || loading || isAtLimit()}
                   sx={{
                     px: 4,
                     py: 1.5,
                     minHeight: '48px',
+                    opacity: isAtLimit() ? 0.6 : 1,
                   }}
                 >
                   {loading ? 'Loading...' : 'Create 3-Leg Parlay'}

--- a/src/components/GameSelector.tsx
+++ b/src/components/GameSelector.tsx
@@ -32,6 +32,8 @@ interface GameSelectorProps {
   onWeekChange: (week: number) => void
   availableWeeks: number[]
   weekLoading?: boolean
+  // Error props
+  parlayError?: Error | null
 }
 
 const GameSelector: React.FC<GameSelectorProps> = ({
@@ -41,13 +43,13 @@ const GameSelector: React.FC<GameSelectorProps> = ({
   onWeekChange,
   availableWeeks,
   weekLoading = false,
+  parlayError,
 }) => {
   // Use PFR schedule hook and filter by current week
   const { data: allGames, isLoading: loading, error } = usePFRSchedule()
 
   // Rate limiting hook
-  const { rateLimitInfo, isAtLimit, isNearLimit, getTimeUntilReset } =
-    useRateLimit()
+  const { rateLimitInfo, isAtLimit, getTimeUntilReset } = useRateLimit()
 
   const games = allGames?.filter(game => game.week === currentWeek) || []
   const selectedGame = useParlayStore(state => state.selectedGame)
@@ -100,13 +102,11 @@ const GameSelector: React.FC<GameSelectorProps> = ({
     return (
       <Card sx={{ mb: 3 }}>
         <CardContent sx={{ textAlign: 'center', py: 4 }}>
-          <Typography variant="body1" color="error" sx={{ mb: 2 }}>
-            Error loading games:{' '}
-            {error instanceof Error ? error.message : String(error)}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Please try again or select a different week
-          </Typography>
+          <ErrorBanner
+            type="error"
+            title="Error loading games"
+            message={`${error instanceof Error ? error.message : String(error)}. Please try again or select a different week.`}
+          />
         </CardContent>
       </Card>
     )
@@ -321,15 +321,18 @@ const GameSelector: React.FC<GameSelectorProps> = ({
                         countdown={getTimeUntilReset()}
                       />
                     )}
-                    {isNearLimit() && !isAtLimit() && (
-                      <ErrorBanner
-                        type="rate_limit_warning"
-                        message="You're approaching your hourly limit"
-                        countdown={getTimeUntilReset()}
-                      />
-                    )}
                   </>
                 )}
+
+                {/* Parlay generation errors (excluding rate limit errors) */}
+                {parlayError &&
+                  !parlayError.message?.includes('Rate limit exceeded') && (
+                    <ErrorBanner
+                      type="error"
+                      title="Error generating parlay"
+                      message={parlayError.message}
+                    />
+                  )}
 
                 <Button
                   variant="contained"

--- a/src/components/ParlayHistory.tsx
+++ b/src/components/ParlayHistory.tsx
@@ -162,11 +162,11 @@ export const ParlayHistory: React.FC<ParlayHistoryProps> = ({
                   {/* savedAt removed in v2 */}
 
                   <Grid container spacing={2}>
-                    {parlay.legs?.map((leg, legIndex) => (
+                    {parlay.legs?.map((leg, _legIndex) => (
                       <Grid
                         item
                         xs={12}
-                        key={`${parlay.parlayId}-${leg.betType}-${leg.selection}-${legIndex}`}
+                        key={`${parlay.parlayId}-${leg.betType}-${leg.selection}-${leg.odds}-${leg.confidence}`}
                       >
                         <Box
                           sx={{

--- a/src/components/RateLimitStatusBanner.tsx
+++ b/src/components/RateLimitStatusBanner.tsx
@@ -1,0 +1,102 @@
+import { AccessTime as AccessTimeIcon } from '@mui/icons-material'
+import { Alert, Box, Chip, Typography } from '@mui/material'
+import React from 'react'
+
+export type ErrorBannerType =
+  | 'rate_limit_reached'
+  | 'rate_limit_warning'
+  | 'error'
+  | 'info'
+  | 'success'
+
+interface ErrorBannerProps {
+  type: ErrorBannerType
+  title?: string
+  message: string
+  countdown?: string
+  icon?: React.ReactNode
+  show?: boolean
+}
+
+/**
+ * Generic Error Banner Component
+ * Shows various types of error and status messages with appropriate styling
+ */
+export const ErrorBanner: React.FC<ErrorBannerProps> = ({
+  type,
+  title,
+  message,
+  countdown,
+  icon,
+  show = true,
+}) => {
+  if (!show) {
+    return null
+  }
+
+  const getSeverity = () => {
+    switch (type) {
+      case 'rate_limit_reached':
+        return 'warning'
+      case 'rate_limit_warning':
+        return 'info'
+      case 'error':
+        return 'error'
+      case 'info':
+        return 'info'
+      case 'success':
+        return 'success'
+      default:
+        return 'info'
+    }
+  }
+
+  const getDefaultIcon = () => {
+    switch (type) {
+      case 'rate_limit_reached':
+      case 'rate_limit_warning':
+        return <AccessTimeIcon />
+      default:
+        return undefined
+    }
+  }
+
+  const severity = getSeverity()
+  const displayIcon = icon || getDefaultIcon()
+
+  return (
+    <Alert
+      severity={severity}
+      icon={displayIcon}
+      sx={{
+        mb: 2,
+        '& .MuiAlert-message': {
+          width: '100%',
+        },
+      }}
+    >
+      <Box sx={{ textAlign: 'center' }}>
+        {title && (
+          <Typography variant="body2" sx={{ fontWeight: 500, mb: 1 }}>
+            {title}
+          </Typography>
+        )}
+        <Typography variant="body2" color="text.secondary">
+          {message}
+        </Typography>
+        {countdown && (
+          <Box sx={{ mt: 1 }}>
+            <Chip
+              label={countdown}
+              size="small"
+              color="primary"
+              variant="outlined"
+            />
+          </Box>
+        )}
+      </Box>
+    </Alert>
+  )
+}
+
+export default ErrorBanner

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -17,6 +17,8 @@ import {
 import React, { useState } from 'react'
 import { logOut } from '../../config/firebase'
 import { useAuth } from '../../hooks/useAuth'
+import { FrontendRateLimiter } from '../../services/FrontendRateLimiter'
+import useRateLimitStore from '../../store/rateLimitStore'
 import { AuthModal } from './AuthModal'
 
 interface UserMenuProps {
@@ -25,6 +27,7 @@ interface UserMenuProps {
 
 export const UserMenu: React.FC<UserMenuProps> = ({ onViewHistory }) => {
   const { user, userProfile } = useAuth()
+  const { clearRateLimitInfo } = useRateLimitStore()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [authModalOpen, setAuthModalOpen] = useState(false)
 
@@ -38,6 +41,12 @@ export const UserMenu: React.FC<UserMenuProps> = ({ onViewHistory }) => {
 
   const handleLogout = async () => {
     try {
+      // Clear rate limit data for this user on logout
+      if (user?.uid) {
+        FrontendRateLimiter.reset(user.uid)
+        clearRateLimitInfo() // Also clear the store
+      }
+
       await logOut()
       handleMenuClose()
     } catch (error) {

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from '@mui/material'
 import React, { useState } from 'react'
+import { API_CONFIG } from '../../config/api'
 import { logOut } from '../../config/firebase'
 import { useAuth } from '../../hooks/useAuth'
 import { FrontendRateLimiter } from '../../services/FrontendRateLimiter'
@@ -27,7 +28,7 @@ interface UserMenuProps {
 
 export const UserMenu: React.FC<UserMenuProps> = ({ onViewHistory }) => {
   const { user, userProfile } = useAuth()
-  const { clearRateLimitInfo } = useRateLimitStore()
+  const { clearPersistedData } = useRateLimitStore()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [authModalOpen, setAuthModalOpen] = useState(false)
 
@@ -43,8 +44,34 @@ export const UserMenu: React.FC<UserMenuProps> = ({ onViewHistory }) => {
     try {
       // Clear rate limit data for this user on logout
       if (user?.uid) {
+        // Clear frontend rate limits
         FrontendRateLimiter.reset(user.uid)
-        clearRateLimitInfo() // Also clear the store
+        FrontendRateLimiter.clearAll() // Clear all rate limit data
+        clearPersistedData() // Clear both in-memory and persisted store data
+
+        // Clear backend rate limits
+        try {
+          const token = await user.getIdToken()
+          const response = await fetch(
+            `${API_CONFIG.CLOUD_FUNCTIONS.baseURL}/api/rate-limits/clear`,
+            {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json',
+              },
+            }
+          )
+
+          if (!response.ok) {
+            console.warn(
+              'Failed to clear backend rate limits:',
+              response.status
+            )
+          }
+        } catch (error) {
+          console.error('Error clearing backend rate limits:', error)
+        }
       }
 
       await logOut()

--- a/src/components/display/ParlayDisplay.tsx
+++ b/src/components/display/ParlayDisplay.tsx
@@ -21,6 +21,7 @@ import useModalStore from '../../store/modalStore'
 import useParlayStore from '../../store/parlayStore'
 import type { GeneratedParlay } from '../../types'
 import { AuthModal } from '../auth/AuthModal'
+import ErrorBanner from '../ErrorBanner'
 import GameSummaryView from './GameSummaryView'
 import ParlayDisplayFooter from './ParlayDisplayFooter'
 import ParlayLanding from './ParlayLanding'
@@ -126,13 +127,11 @@ const ParlayDisplay: React.FC<ParlayDisplayProps> = ({ parlay, loading }) => {
           )}
 
           {saveParlayError && (
-            <Alert
-              severity="error"
-              sx={{ mb: 2 }}
-              onClose={() => setSaveParlayError('')}
-            >
-              {saveParlayError}
-            </Alert>
+            <ErrorBanner
+              type="error"
+              title="Failed to save parlay"
+              message={saveParlayError}
+            />
           )}
 
           {/* Save Button */}

--- a/src/components/display/ParlayDisplay.tsx
+++ b/src/components/display/ParlayDisplay.tsx
@@ -111,7 +111,7 @@ const ParlayDisplay: React.FC<ParlayDisplayProps> = ({ parlay, loading }) => {
           <Grid container spacing={2} sx={{ mb: 3 }}>
             {parlay.legs.map((leg, index) => (
               <ParlayLegView
-                key={`${parlay.parlayId}-${leg.betType}-${leg.selection}-${leg.odds}-${index}`}
+                key={`${parlay.parlayId}-${leg.betType}-${leg.selection}-${leg.odds}-${leg.confidence}`}
                 leg={leg}
                 index={index}
               />

--- a/src/components/display/ParlayLanding.tsx
+++ b/src/components/display/ParlayLanding.tsx
@@ -1,14 +1,24 @@
 import { Card, CardContent, Typography } from '@mui/material'
 import React from 'react'
+import useRateLimitStore from '../../store/rateLimitStore'
 
-const ParlayLanding: React.FC = () => (
-  <Card>
-    <CardContent sx={{ textAlign: 'center', py: 4 }}>
-      <Typography variant="h6" color="text.secondary">
-        {`Select a game and click "Create 3-Leg Parlay" to get started`}
-      </Typography>
-    </CardContent>
-  </Card>
-)
+const ParlayLanding: React.FC = () => {
+  const isAtLimit = useRateLimitStore(state => state.isAtLimit)
+
+  // Hide the component when rate limited
+  if (isAtLimit()) {
+    return null
+  }
+
+  return (
+    <Card>
+      <CardContent sx={{ textAlign: 'center', py: 4 }}>
+        <Typography variant="h6" color="text.secondary">
+          Select a game and click "Create 3-Leg Parlay" to get started
+        </Typography>
+      </CardContent>
+    </Card>
+  )
+}
 
 export default ParlayLanding

--- a/src/components/display/ParlayLanding.tsx
+++ b/src/components/display/ParlayLanding.tsx
@@ -14,7 +14,7 @@ const ParlayLanding: React.FC = () => {
     <Card>
       <CardContent sx={{ textAlign: 'center', py: 4 }}>
         <Typography variant="h6" color="text.secondary">
-          Select a game and click "Create 3-Leg Parlay" to get started
+          Select a game and click &quot;Create 3-Leg Parlay&quot; to get started
         </Typography>
       </CardContent>
     </Card>

--- a/src/components/display/TeamLogo.tsx
+++ b/src/components/display/TeamLogo.tsx
@@ -33,8 +33,9 @@ const TeamLogo: React.FC<TeamLogoProps> = ({
     let isMounted = true
 
     const loadLogo = async () => {
-      if (!teamName) {
+      if (!teamName || teamName.trim().length < 2) {
         setIsLoading(false)
+        setHasError(true)
         return
       }
 
@@ -46,7 +47,11 @@ const TeamLogo: React.FC<TeamLogoProps> = ({
         const url = getTeamLogoUrl(teamName)
 
         if (isMounted) {
-          setLogoUrl(url)
+          if (url) {
+            setLogoUrl(url)
+          } else {
+            setHasError(true)
+          }
           setIsLoading(false)
         }
       } catch {
@@ -65,7 +70,11 @@ const TeamLogo: React.FC<TeamLogoProps> = ({
   }, [teamName])
 
   const dimensions = sizeMap[size]
-  const fallbackDisplayText = fallbackText || teamName.slice(0, 3).toUpperCase()
+  const fallbackDisplayText =
+    fallbackText ||
+    (teamName && teamName.length >= 2
+      ? teamName.slice(0, 3).toUpperCase()
+      : 'UNK')
 
   if (isLoading) {
     return (

--- a/src/contexts/authentication/AuthContext.tsx
+++ b/src/contexts/authentication/AuthContext.tsx
@@ -6,6 +6,7 @@ import {
   getUserProfile,
   UserProfile,
 } from '../../config/firebase'
+import { FrontendRateLimiter } from '../../services/FrontendRateLimiter'
 import { AuthContext } from './auth'
 
 const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
@@ -29,7 +30,9 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           setProfileLoading(false)
         }
       } else {
+        // User logged out - clear rate limits for session strategy
         setUserProfile(null)
+        FrontendRateLimiter.clearForUser(null) // Clear for current session
       }
     }
 

--- a/src/hooks/useParlayGenerator.ts
+++ b/src/hooks/useParlayGenerator.ts
@@ -1,5 +1,6 @@
 // src/hooks/useParlayGenerator.ts - Fixed version
 import { useMutation } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'react'
 import { ServiceContainer } from '../services/container'
 import useParlayStore from '../store/parlayStore'
 import { Game } from '../types'
@@ -9,6 +10,149 @@ import { useRateLimit } from './useRateLimit'
 export const useParlayGenerator = () => {
   const setParlay = useParlayStore(state => state.setParlay)
   const { updateFromResponse } = useRateLimit()
+
+  // Retry state
+  const [isRetrying, setIsRetrying] = useState(false)
+  const [hasExhaustedRetries, setHasExhaustedRetries] = useState(false)
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  // Cleanup effect to cancel requests on unmount
+  useEffect(() => {
+    return () => {
+      cancelRequests()
+    }
+  }, [])
+
+  // Helper function to determine if an error is retryable
+  const isRetryableError = (error: Error): boolean => {
+    const retryablePatterns = [
+      'ai_service_unavailable',
+      'service temporarily unavailable',
+      'network error',
+      'timeout',
+      'connection failed',
+      'internal server error',
+      'bad gateway',
+      'service unavailable',
+    ]
+
+    return retryablePatterns.some(pattern =>
+      error.message.toLowerCase().includes(pattern.toLowerCase())
+    )
+  }
+
+  // Cancel any ongoing requests
+  const cancelRequests = () => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+      abortControllerRef.current = null
+    }
+  }
+
+  // Reset retry state
+  const resetRetryState = () => {
+    setIsRetrying(false)
+    setHasExhaustedRetries(false)
+    cancelRequests()
+  }
+
+  // Retry function with proper cancellation and error handling
+  const retryGeneration = async (
+    game: Game,
+    shouldUseMock: boolean,
+    attemptNumber: number
+  ): Promise<void> => {
+    // Check if we've already exhausted retries
+    if (hasExhaustedRetries) {
+      console.info('Retries already exhausted, not attempting retry')
+      return
+    }
+
+    // Check if we've reached max attempts (3 total attempts: 1 initial + 2 retries)
+    if (attemptNumber > 2) {
+      console.info('Max retries reached, giving up')
+      setIsRetrying(false)
+      setHasExhaustedRetries(true)
+      setParlay(null) // Clear parlay to show error state
+      return
+    }
+
+    console.info(`Retrying parlay generation (attempt ${attemptNumber + 1}/3)`)
+    setIsRetrying(true)
+
+    // Cancel any previous request
+    cancelRequests()
+
+    // Create new abort controller for this retry
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
+
+    // Wait 2 seconds before retry
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    // Check if request was cancelled during wait
+    if (abortController.signal.aborted) {
+      console.info('Retry cancelled during wait period')
+      return
+    }
+
+    try {
+      const provider = shouldUseMock ? 'mock' : 'openai'
+      const parlayService = ServiceContainer.instance.getParlayService(provider)
+      const result = await parlayService.generateParlay(game)
+
+      // Check if request was cancelled during execution
+      if (abortController.signal.aborted) {
+        console.info('Retry cancelled during execution')
+        return
+      }
+
+      // Success - reset retry state
+      resetRetryState()
+
+      // Handle success
+      if (result.rateLimitInfo) {
+        updateFromResponse({
+          rateLimitInfo: {
+            remaining: result.rateLimitInfo.remaining,
+            total: result.rateLimitInfo.total || 20,
+            resetTime:
+              typeof result.rateLimitInfo.resetTime === 'string'
+                ? new Date(result.rateLimitInfo.resetTime)
+                : result.rateLimitInfo.resetTime,
+            currentCount: result.rateLimitInfo.currentCount,
+          },
+        })
+      }
+
+      // Store the parlay data with gameData attached for UI consumption
+      const parlayWithGameData = {
+        ...result.parlay,
+        gameData: result.gameData,
+      }
+
+      setParlay(parlayWithGameData)
+    } catch (retryError) {
+      // Check if request was cancelled
+      if (abortController.signal.aborted) {
+        console.info('Retry cancelled, not processing error')
+        return
+      }
+
+      console.error(`Retry attempt ${attemptNumber + 1} failed:`, retryError)
+
+      if (isRetryableError(retryError as Error) && attemptNumber < 2) {
+        // Try again
+        await retryGeneration(game, shouldUseMock, attemptNumber + 1)
+      } else {
+        // Final failure - exhaust retries
+        console.error('All retry attempts failed, exhausting retries')
+        setIsRetrying(false)
+        setHasExhaustedRetries(true)
+        setParlay(null) // Clear parlay to show error state
+      }
+    }
+  }
 
   const mutation = useMutation({
     mutationFn: async ({
@@ -22,7 +166,7 @@ export const useParlayGenerator = () => {
       const parlayService = ServiceContainer.instance.getParlayService(provider)
       return await parlayService.generateParlay(game)
     },
-    onError: error => {
+    onError: async (error, variables) => {
       console.error('Error generating parlay:', error)
 
       // Handle authentication errors specifically
@@ -31,17 +175,38 @@ export const useParlayGenerator = () => {
         error.message.includes('not authenticated')
       ) {
         console.error('Authentication required - user needs to log in')
-        // You could trigger a re-authentication flow here if needed
+        resetRetryState()
+        setParlay(null)
+        return
       }
 
       if (error instanceof RateLimitError) {
         console.warn('Rate limit exceeded:', error.rateLimitInfo)
         updateFromResponse({ rateLimitInfo: error.rateLimitInfo })
+        resetRetryState()
+        setParlay(null)
+        return
       }
 
+      // Check if error is retryable and we haven't exhausted retries
+      if (
+        error instanceof Error &&
+        isRetryableError(error) &&
+        !hasExhaustedRetries
+      ) {
+        console.info('Retryable error detected, attempting retry...')
+        await retryGeneration(variables.game, variables.shouldUseMock, 0) // Start with attempt 0 (first retry)
+        return // Don't set parlay to null here, let retryGeneration handle it
+      }
+
+      // Non-retryable error or retries exhausted
+      resetRetryState()
       setParlay(null)
     },
     onSuccess: data => {
+      // Reset retry state on success
+      resetRetryState()
+
       if (data.rateLimitInfo) {
         updateFromResponse({
           rateLimitInfo: {
@@ -69,11 +234,16 @@ export const useParlayGenerator = () => {
   return {
     mutate: mutation.mutate, // Return 'mutate' to match App.tsx expectations
     data: mutation.data?.parlay,
-    isPending: mutation.isPending, // Return 'isPending' to match App.tsx expectations
-    isError: mutation.isError,
+    isPending: mutation.isPending || isRetrying, // Include retry state in pending
+    isError: mutation.isError || hasExhaustedRetries, // Include exhausted retries as error state
     error: mutation.error,
-    reset: mutation.reset,
+    reset: () => {
+      mutation.reset()
+      resetRetryState()
+    },
     isSuccess: mutation.isSuccess,
+    // Remove retry-related UI state - only keep for internal use
+    cancelRequests, // Expose cancel function for external use
   }
 }
 

--- a/src/hooks/useParlayGenerator.ts
+++ b/src/hooks/useParlayGenerator.ts
@@ -46,7 +46,7 @@ export const useParlayGenerator = () => {
         updateFromResponse({
           rateLimitInfo: {
             remaining: data.rateLimitInfo.remaining,
-            total: data.rateLimitInfo.total || 10,
+            total: data.rateLimitInfo.total || 20,
             resetTime:
               typeof data.rateLimitInfo.resetTime === 'string'
                 ? new Date(data.rateLimitInfo.resetTime)

--- a/src/hooks/useRateLimit.ts
+++ b/src/hooks/useRateLimit.ts
@@ -12,13 +12,6 @@ interface RateLimitInfo {
   currentCount: number
 }
 
-// interface RateLimitResponse {
-//   success: boolean
-//   data?: RateLimitInfo & { resetTime: string } // API returns string, we convert to Date
-//   error?: string
-// }
-
-// Updated interface to make rateLimitInfo required when passed
 interface ParlayGenerationResponse {
   rateLimitInfo: {
     remaining: number

--- a/src/hooks/useRateLimit.ts
+++ b/src/hooks/useRateLimit.ts
@@ -49,11 +49,7 @@ export const useRateLimit = () => {
     queryKey: ['rateLimitStatus', user?.uid],
     queryFn: async (): Promise<RateLimitInfo> => {
       // Get current rate limit status from frontend rate limiter
-      return FrontendRateLimiter.getCurrentStatus(
-        20,
-        60 * 60 * 1000,
-        user?.uid || null
-      )
+      return FrontendRateLimiter.getCurrentStatus(user?.uid || null)
     },
     enabled: true, // Enabled - uses frontend rate limiter for both mock and real data
     refetchInterval: 30000, // Refetch every 30 seconds
@@ -87,7 +83,7 @@ export const useRateLimit = () => {
       storeUpdateFromResponse({
         rateLimitInfo: {
           remaining: responseData.rateLimitInfo.remaining,
-          total: responseData.rateLimitInfo.total || 20, // Default to 20 if not provided
+          total: responseData.rateLimitInfo.total || 20, // Default to 20
           resetTime: responseData.rateLimitInfo.resetTime,
           currentCount: responseData.rateLimitInfo.currentCount,
         },

--- a/src/hooks/useRateLimit.ts
+++ b/src/hooks/useRateLimit.ts
@@ -74,6 +74,14 @@ export const useRateLimit = () => {
     }
   }, [data, setRateLimitInfo])
 
+  // Clear rate limit info when user logs out
+  useEffect(() => {
+    if (!user && !loading) {
+      // User logged out - clear rate limit info from store
+      setRateLimitInfo(null)
+    }
+  }, [user, loading, setRateLimitInfo])
+
   /**
    * Update rate limit info from a parlay generation response
    * This allows real-time updates when rate limits change
@@ -120,6 +128,14 @@ export const useRateLimit = () => {
     return storeIsAtLimit()
   }
 
+  /**
+   * Manually reset rate limits (for testing or admin purposes)
+   */
+  const resetRateLimit = (): void => {
+    FrontendRateLimiter.reset(user?.uid || null)
+    refetch() // Refresh the rate limit status
+  }
+
   return {
     rateLimitInfo,
     isLoading: isLoading || loading,
@@ -130,6 +146,7 @@ export const useRateLimit = () => {
     getTimeUntilReset,
     isNearLimit,
     isAtLimit,
+    resetRateLimit,
     isAuthenticated: !!user,
     userId: user?.uid,
   }

--- a/src/hooks/useRateLimit.ts
+++ b/src/hooks/useRateLimit.ts
@@ -1,7 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useAuthState } from 'react-firebase-hooks/auth'
 import { auth } from '../config/firebase'
+import { FrontendRateLimiter } from '../services/FrontendRateLimiter'
+import useRateLimitStore from '../store/rateLimitStore'
 
 interface RateLimitInfo {
   remaining: number
@@ -33,21 +35,27 @@ interface ParlayGenerationResponse {
  */
 export const useRateLimit = () => {
   const [user, loading] = useAuthState(auth)
-  const [rateLimitInfo, setRateLimitInfo] = useState<RateLimitInfo | null>(null)
+  const {
+    rateLimitInfo,
+    setRateLimitInfo,
+    updateFromResponse: storeUpdateFromResponse,
+    isNearLimit: storeIsNearLimit,
+    isAtLimit: storeIsAtLimit,
+    getTimeUntilReset: storeGetTimeUntilReset,
+  } = useRateLimitStore()
 
-  // Query rate limit status - DISABLED for v2 (no rate limit endpoint yet)
+  // Query rate limit status - ENABLED for v2 with unified frontend rate limiting
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['rateLimitStatus', user?.uid],
     queryFn: async (): Promise<RateLimitInfo> => {
-      // API doesn't have rate limit status endpoint yet, return default values
-      return {
-        remaining: 10,
-        total: 10,
-        currentCount: 0,
-        resetTime: new Date(Date.now() + 30 * 60 * 1000), // 30 minutes from now
-      }
+      // Get current rate limit status from frontend rate limiter
+      return FrontendRateLimiter.getCurrentStatus(
+        20,
+        60 * 60 * 1000,
+        user?.uid || null
+      )
     },
-    enabled: false, // Disabled until v2 rate limit endpoint is added
+    enabled: true, // Enabled - uses frontend rate limiter for both mock and real data
     refetchInterval: 30000, // Refetch every 30 seconds
     staleTime: 15000, // Consider data stale after 15 seconds
     retry: (failureCount, error) => {
@@ -63,12 +71,12 @@ export const useRateLimit = () => {
     retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 30000),
   })
 
-  // Update local state when query data changes
+  // Update store when query data changes
   useEffect(() => {
     if (data) {
       setRateLimitInfo(data)
     }
-  }, [data])
+  }, [data, setRateLimitInfo])
 
   /**
    * Update rate limit info from a parlay generation response
@@ -76,19 +84,14 @@ export const useRateLimit = () => {
    */
   const updateFromResponse = (responseData: ParlayGenerationResponse) => {
     if (responseData.rateLimitInfo) {
-      const resetTime =
-        typeof responseData.rateLimitInfo.resetTime === 'string'
-          ? new Date(responseData.rateLimitInfo.resetTime)
-          : responseData.rateLimitInfo.resetTime
-
-      const updatedInfo: RateLimitInfo = {
-        remaining: responseData.rateLimitInfo.remaining,
-        total: responseData.rateLimitInfo.total || rateLimitInfo?.total || 10, // Use existing total or default
-        resetTime,
-        currentCount: responseData.rateLimitInfo.currentCount,
-      }
-
-      setRateLimitInfo(updatedInfo)
+      storeUpdateFromResponse({
+        rateLimitInfo: {
+          remaining: responseData.rateLimitInfo.remaining,
+          total: responseData.rateLimitInfo.total || 20, // Default to 20 if not provided
+          resetTime: responseData.rateLimitInfo.resetTime,
+          currentCount: responseData.rateLimitInfo.currentCount,
+        },
+      })
     }
   }
 
@@ -104,43 +107,21 @@ export const useRateLimit = () => {
    * Get a formatted string showing time until reset
    */
   const getTimeUntilReset = (): string => {
-    if (!rateLimitInfo?.resetTime) {
-      return ''
-    }
-
-    const now = new Date()
-    const resetTime = new Date(rateLimitInfo.resetTime)
-    const timeDiff = resetTime.getTime() - now.getTime()
-
-    if (timeDiff <= 0) {
-      return 'Reset available'
-    }
-
-    const minutes = Math.floor(timeDiff / (1000 * 60))
-    const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000)
-
-    if (minutes > 0) {
-      return `${minutes}m ${seconds}s`
-    }
-    return `${seconds}s`
+    return storeGetTimeUntilReset()
   }
 
   /**
    * Check if user is near rate limit (less than 20% remaining)
    */
   const isNearLimit = (): boolean => {
-    if (!rateLimitInfo) {
-      return false
-    }
-    const percentRemaining = rateLimitInfo.remaining / rateLimitInfo.total
-    return percentRemaining < 0.2
+    return storeIsNearLimit()
   }
 
   /**
    * Check if user has hit rate limit
    */
   const isAtLimit = (): boolean => {
-    return rateLimitInfo?.remaining === 0
+    return storeIsAtLimit()
   }
 
   return {

--- a/src/services/FrontendRateLimiter.ts
+++ b/src/services/FrontendRateLimiter.ts
@@ -44,9 +44,6 @@ export class FrontendRateLimiter {
       updatedRecord = { count: 1, windowStart: now }
     } else if (now - record.windowStart >= windowMs) {
       // Window has expired, reset
-      console.log(
-        `Rate limit window expired for key: ${key}. Resetting window.`
-      )
       updatedRecord = { count: 1, windowStart: now }
     } else if (record.count >= limit) {
       // Rate limit exceeded
@@ -105,9 +102,6 @@ export class FrontendRateLimiter {
 
     if (now - record.windowStart >= windowMs) {
       // Window has expired - clear the expired record and return fresh status
-      console.log(
-        `Rate limit window expired for key: ${key}. Clearing expired record.`
-      )
       this.setRecord(key, { count: 0, windowStart: now })
       return {
         remaining: limit,

--- a/src/services/FrontendRateLimiter.ts
+++ b/src/services/FrontendRateLimiter.ts
@@ -1,0 +1,190 @@
+interface RateLimitInfo {
+  remaining: number
+  total: number
+  resetTime: Date
+  currentCount: number
+}
+
+interface RateLimitRecord {
+  count: number
+  windowStart: number
+}
+
+/**
+ * Frontend rate limiter that works independently of API calls
+ * Tracks rate limits in localStorage and works for both mock and real data
+ *
+ * Rate limiting strategies:
+ * - 'global': Rate limit applies to all users on this device (persists across logouts)
+ * - 'user': Rate limit is per-user but persists across logouts for security
+ * - 'session': Rate limit resets on logout (better UX, industry standard)
+ */
+export class FrontendRateLimiter {
+  private static readonly STORAGE_KEY_PREFIX = 'nfl-parlay-rate-limit'
+  private static readonly DEFAULT_LIMIT = 20
+  private static readonly DEFAULT_WINDOW_MS = 60 * 60 * 1000 // 1 hour
+  private static readonly STRATEGY: 'global' | 'user' | 'session' = 'session' // Default strategy
+
+  /**
+   * Check if a request is allowed and increment the counter
+   */
+  static async checkAndIncrement(
+    limit: number = this.DEFAULT_LIMIT,
+    windowMs: number = this.DEFAULT_WINDOW_MS,
+    userId?: string | null
+  ): Promise<{ allowed: boolean; rateLimitInfo: RateLimitInfo }> {
+    const now = Date.now()
+    const key = this.getStorageKey(userId)
+    const record = this.getRecord(key)
+
+    let updatedRecord: RateLimitRecord
+
+    if (!record) {
+      // First request in this window
+      updatedRecord = { count: 1, windowStart: now }
+    } else if (now - record.windowStart >= windowMs) {
+      // Window has expired, reset
+      updatedRecord = { count: 1, windowStart: now }
+    } else if (record.count >= limit) {
+      // Rate limit exceeded
+      return {
+        allowed: false,
+        rateLimitInfo: {
+          remaining: 0,
+          total: limit,
+          resetTime: new Date(record.windowStart + windowMs),
+          currentCount: record.count,
+        },
+      }
+    } else {
+      // Increment counter
+      updatedRecord = {
+        count: record.count + 1,
+        windowStart: record.windowStart,
+      }
+    }
+
+    // Save updated record
+    this.setRecord(key, updatedRecord)
+
+    const remaining = Math.max(0, limit - updatedRecord.count)
+    const resetTime = new Date(updatedRecord.windowStart + windowMs)
+
+    return {
+      allowed: true,
+      rateLimitInfo: {
+        remaining,
+        total: limit,
+        resetTime,
+        currentCount: updatedRecord.count,
+      },
+    }
+  }
+
+  /**
+   * Get current rate limit status without incrementing
+   */
+  static getCurrentStatus(
+    limit: number = this.DEFAULT_LIMIT,
+    windowMs: number = this.DEFAULT_WINDOW_MS,
+    userId?: string | null
+  ): RateLimitInfo {
+    const now = Date.now()
+    const key = this.getStorageKey(userId)
+    const record = this.getRecord(key)
+
+    if (!record) {
+      return {
+        remaining: limit,
+        total: limit,
+        resetTime: new Date(now + windowMs),
+        currentCount: 0,
+      }
+    }
+
+    if (now - record.windowStart >= windowMs) {
+      // Window has expired
+      return {
+        remaining: limit,
+        total: limit,
+        resetTime: new Date(now + windowMs),
+        currentCount: 0,
+      }
+    }
+
+    const remaining = Math.max(0, limit - record.count)
+    const resetTime = new Date(record.windowStart + windowMs)
+
+    return {
+      remaining,
+      total: limit,
+      resetTime,
+      currentCount: record.count,
+    }
+  }
+
+  /**
+   * Reset rate limit (for testing or admin purposes)
+   */
+  static reset(userId?: string | null): void {
+    const key = this.getStorageKey(userId)
+    localStorage.removeItem(key)
+  }
+
+  /**
+   * Clear all rate limit data (for logout or admin purposes)
+   */
+  static clearAll(): void {
+    // Clear all rate limit keys
+    const keys = Object.keys(localStorage)
+    keys.forEach(key => {
+      if (key.startsWith(this.STORAGE_KEY_PREFIX)) {
+        localStorage.removeItem(key)
+      }
+    })
+  }
+
+  /**
+   * Get storage key based on strategy and user ID
+   */
+  private static getStorageKey(userId?: string | null): string {
+    switch (this.STRATEGY) {
+      case 'global':
+        return this.STORAGE_KEY_PREFIX
+      case 'user':
+        return userId
+          ? `${this.STORAGE_KEY_PREFIX}-user-${userId}`
+          : this.STORAGE_KEY_PREFIX
+      case 'session':
+        return userId
+          ? `${this.STORAGE_KEY_PREFIX}-session-${userId}`
+          : this.STORAGE_KEY_PREFIX
+      default:
+        return this.STORAGE_KEY_PREFIX
+    }
+  }
+
+  /**
+   * Get rate limit record from localStorage
+   */
+  private static getRecord(key: string): RateLimitRecord | null {
+    try {
+      const stored = localStorage.getItem(key)
+      if (!stored) return null
+      return JSON.parse(stored) as RateLimitRecord
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Set rate limit record in localStorage
+   */
+  private static setRecord(key: string, record: RateLimitRecord): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(record))
+    } catch (error) {
+      console.warn('Failed to save rate limit record:', error)
+    }
+  }
+}

--- a/src/services/FrontendRateLimiter.ts
+++ b/src/services/FrontendRateLimiter.ts
@@ -44,6 +44,9 @@ export class FrontendRateLimiter {
       updatedRecord = { count: 1, windowStart: now }
     } else if (now - record.windowStart >= windowMs) {
       // Window has expired, reset
+      console.log(
+        `Rate limit window expired for key: ${key}. Resetting window.`
+      )
       updatedRecord = { count: 1, windowStart: now }
     } else if (record.count >= limit) {
       // Rate limit exceeded
@@ -101,7 +104,11 @@ export class FrontendRateLimiter {
     }
 
     if (now - record.windowStart >= windowMs) {
-      // Window has expired
+      // Window has expired - clear the expired record and return fresh status
+      console.log(
+        `Rate limit window expired for key: ${key}. Clearing expired record.`
+      )
+      this.setRecord(key, { count: 0, windowStart: now })
       return {
         remaining: limit,
         total: limit,
@@ -125,6 +132,14 @@ export class FrontendRateLimiter {
    * Reset rate limit (for testing or admin purposes)
    */
   static reset(userId?: string | null): void {
+    const key = this.getStorageKey(userId)
+    localStorage.removeItem(key)
+  }
+
+  /**
+   * Clear rate limit data for a specific user (for logout)
+   */
+  static clearForUser(userId?: string | null): void {
     const key = this.getStorageKey(userId)
     localStorage.removeItem(key)
   }

--- a/src/services/FrontendRateLimiter.ts
+++ b/src/services/FrontendRateLimiter.ts
@@ -84,11 +84,9 @@ export class FrontendRateLimiter {
   /**
    * Get current rate limit status without incrementing
    */
-  static getCurrentStatus(
-    limit: number = this.DEFAULT_LIMIT,
-    windowMs: number = this.DEFAULT_WINDOW_MS,
-    userId?: string | null
-  ): RateLimitInfo {
+  static getCurrentStatus(userId?: string | null): RateLimitInfo {
+    const limit = this.DEFAULT_LIMIT
+    const windowMs = this.DEFAULT_WINDOW_MS
     const now = Date.now()
     const key = this.getStorageKey(userId)
     const record = this.getRecord(key)
@@ -170,7 +168,9 @@ export class FrontendRateLimiter {
   private static getRecord(key: string): RateLimitRecord | null {
     try {
       const stored = localStorage.getItem(key)
-      if (!stored) return null
+      if (!stored) {
+        return null
+      }
       return JSON.parse(stored) as RateLimitRecord
     } catch {
       return null

--- a/src/services/MockParlayService.ts
+++ b/src/services/MockParlayService.ts
@@ -32,7 +32,7 @@ export class MockParlayService extends BaseParlayService {
     return {
       parlay,
       gameData,
-      rateLimitInfo: undefined, // No rate limiting in mock mode
+      rateLimitInfo: undefined, // No rate limiting for mock data
       metadata: this.createMetadata(
         'mock',
         'mock-generator',

--- a/src/services/RealParlayService.ts
+++ b/src/services/RealParlayService.ts
@@ -8,6 +8,7 @@ import {
   EnhancedParlayGenerationResult,
   ParlayGenerationOptions,
 } from './BaseParlayService'
+import { FrontendRateLimiter } from './FrontendRateLimiter'
 
 /**
  * Real parlay service that makes API calls to cloud functions
@@ -40,6 +41,20 @@ export class RealParlayService extends BaseParlayService {
     _options: ParlayGenerationOptions = {}
   ): Promise<EnhancedParlayGenerationResult> {
     try {
+      // Check frontend rate limit first (for consistency with mock mode)
+      const userId = auth.currentUser?.uid || null
+      const frontendRateLimit = await FrontendRateLimiter.checkAndIncrement(
+        20,
+        60 * 60 * 1000,
+        userId
+      )
+
+      if (!frontendRateLimit.allowed) {
+        throw new Error(
+          `Rate limit exceeded. You have used all ${frontendRateLimit.rateLimitInfo.total} parlay generations for this hour. Please wait until ${frontendRateLimit.rateLimitInfo.resetTime.toLocaleTimeString()} before generating more parlays.`
+        )
+      }
+
       // Require authentication for real API calls
       const currentUser = auth.currentUser
       if (!currentUser) {
@@ -52,10 +67,16 @@ export class RealParlayService extends BaseParlayService {
       const result = await this.callCloudFunction(game)
       const latency = Date.now() - startTime
 
+      // Use frontend rate limit info for consistency (backend rate limiting is still enforced)
       return {
         parlay: result.parlay,
         gameData: result.gameData,
-        rateLimitInfo: undefined,
+        rateLimitInfo: {
+          remaining: frontendRateLimit.rateLimitInfo.remaining,
+          total: frontendRateLimit.rateLimitInfo.total,
+          resetTime: frontendRateLimit.rateLimitInfo.resetTime.toISOString(),
+          currentCount: frontendRateLimit.rateLimitInfo.currentCount,
+        },
         metadata: this.createMetadata(
           'openai',
           'gpt-4',

--- a/src/store/rateLimitStore.ts
+++ b/src/store/rateLimitStore.ts
@@ -24,6 +24,7 @@ interface RateLimitStore {
     }
   }) => void
   clearRateLimitInfo: () => void
+  clearPersistedData: () => void
   isNearLimit: () => boolean
   isAtLimit: () => boolean
   getTimeUntilReset: () => string
@@ -70,6 +71,16 @@ const useRateLimitStore = create<RateLimitStore>()(
           rateLimitInfo: null,
           lastUpdated: null,
         })
+      },
+
+      clearPersistedData: () => {
+        // Clear the in-memory state
+        set({
+          rateLimitInfo: null,
+          lastUpdated: null,
+        })
+        // Clear the persisted data from localStorage
+        localStorage.removeItem('nfl-parlay-rate-limit-store')
       },
 
       isNearLimit: () => {

--- a/src/store/rateLimitStore.ts
+++ b/src/store/rateLimitStore.ts
@@ -1,0 +1,122 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface RateLimitInfo {
+  remaining: number
+  total: number
+  resetTime: Date
+  currentCount: number
+}
+
+interface RateLimitStore {
+  // State
+  rateLimitInfo: RateLimitInfo | null
+  lastUpdated: number | null
+
+  // Actions
+  setRateLimitInfo: (info: RateLimitInfo | null) => void
+  updateFromResponse: (responseData: {
+    rateLimitInfo: {
+      remaining: number
+      total: number
+      resetTime: Date | string
+      currentCount: number
+    }
+  }) => void
+  clearRateLimitInfo: () => void
+  isNearLimit: () => boolean
+  isAtLimit: () => boolean
+  getTimeUntilReset: () => string
+}
+
+const useRateLimitStore = create<RateLimitStore>()(
+  persist(
+    (set, get) => ({
+      // Initial state
+      rateLimitInfo: null,
+      lastUpdated: null,
+
+      // Action implementations
+      setRateLimitInfo: info => {
+        set({
+          rateLimitInfo: info,
+          lastUpdated: info ? Date.now() : null,
+        })
+      },
+
+      updateFromResponse: responseData => {
+        if (responseData.rateLimitInfo) {
+          const resetTime =
+            typeof responseData.rateLimitInfo.resetTime === 'string'
+              ? new Date(responseData.rateLimitInfo.resetTime)
+              : responseData.rateLimitInfo.resetTime
+
+          const updatedInfo: RateLimitInfo = {
+            remaining: responseData.rateLimitInfo.remaining,
+            total: responseData.rateLimitInfo.total,
+            resetTime,
+            currentCount: responseData.rateLimitInfo.currentCount,
+          }
+
+          set({
+            rateLimitInfo: updatedInfo,
+            lastUpdated: Date.now(),
+          })
+        }
+      },
+
+      clearRateLimitInfo: () => {
+        set({
+          rateLimitInfo: null,
+          lastUpdated: null,
+        })
+      },
+
+      isNearLimit: () => {
+        const { rateLimitInfo } = get()
+        if (!rateLimitInfo) {
+          return false
+        }
+        const percentRemaining = rateLimitInfo.remaining / rateLimitInfo.total
+        return percentRemaining < 0.2 // Less than 20% remaining
+      },
+
+      isAtLimit: () => {
+        const { rateLimitInfo } = get()
+        return rateLimitInfo?.remaining === 0
+      },
+
+      getTimeUntilReset: () => {
+        const { rateLimitInfo } = get()
+        if (!rateLimitInfo?.resetTime) {
+          return ''
+        }
+
+        const now = new Date()
+        const resetTime = new Date(rateLimitInfo.resetTime)
+        const timeDiff = resetTime.getTime() - now.getTime()
+
+        if (timeDiff <= 0) {
+          return 'Reset available'
+        }
+
+        const minutes = Math.floor(timeDiff / (1000 * 60))
+        const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000)
+
+        if (minutes > 0) {
+          return `${minutes}m ${seconds}s`
+        }
+        return `${seconds}s`
+      },
+    }),
+    {
+      name: 'nfl-parlay-rate-limit-store', // localStorage key
+      partialize: state => ({
+        rateLimitInfo: state.rateLimitInfo,
+        lastUpdated: state.lastUpdated,
+      }), // Persist rate limit data
+    }
+  )
+)
+
+export default useRateLimitStore

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -273,6 +273,12 @@ export interface GenerateParlayResponse {
     }
   }
   gameData: GameData
+  rateLimitInfo: {
+    remaining: number
+    total: number
+    resetTime: string // ISO string format
+    currentCount: number
+  }
 }
 
 export interface GenerateParlayRequest {

--- a/src/utils/teamLogos.ts
+++ b/src/utils/teamLogos.ts
@@ -56,7 +56,7 @@ const TEAM_ABBREVIATIONS: Record<string, string> = {
 /**
  * Get team abbreviation from team name
  */
-export function getTeamAbbreviation(teamName: string): string {
+export function getTeamAbbreviation(teamName: string): string | null {
   const normalizedName = teamName.toLowerCase().trim()
 
   // Direct match first
@@ -81,14 +81,21 @@ export function getTeamAbbreviation(teamName: string): string {
     }
   }
 
-  // Fallback to first 3 characters
-  return teamName.toUpperCase().slice(0, 3)
+  // Fallback to first 3 characters, but ensure minimum length
+  const fallback = teamName.toUpperCase().slice(0, 3)
+  return fallback.length >= 2 ? fallback : null
 }
 
 /**
  * Generate logo URL using ESPN
  */
-export function getTeamLogoUrl(teamName: string): string {
+export function getTeamLogoUrl(teamName: string): string | null {
+  if (teamName.toLowerCase() === 'both teams') {
+    return null
+  }
+
   const abbreviation = getTeamAbbreviation(teamName)
-  return `https://a.espncdn.com/i/teamlogos/nfl/500/${abbreviation.toLowerCase()}.png`
+  return abbreviation
+    ? `https://a.espncdn.com/i/teamlogos/nfl/500/${abbreviation.toLowerCase()}.png`
+    : null
 }


### PR DESCRIPTION
- Update backend rate limiting from 10/30min to 20/60min
- Add rate limit status functions to middleware
- Include rate limit info in parlay generation responses
- Create FrontendRateLimiter for unified client-side rate limiting
- Add Zustand store for persistent rate limit state management
- Enable rate limiting for both mock and real data modes
- Implement rate limit reset on user logout
- Mock data generation bypasses rate limiting (free)
- Real data generation enforces both frontend and backend limits
- Add comprehensive rate limit UI indicators and warnings
- Fix rate limit counter to properly decrement with each request
- Ensure rate limit data persists across page refreshes and sessions

Backend Changes:
- functions/src/middleware/rateLimit.ts: Add getRateLimitStatus functions
- functions/src/routes/protected/index.ts: Update to 20 requests/hour
- functions/src/routes/protected/handlers.ts: Include rate limit info in responses
- functions/src/routes/protected/schema.ts: Add rateLimitInfo to response schema

Frontend Changes:
- src/services/FrontendRateLimiter.ts: New client-side rate limiter
- src/store/rateLimitStore.ts: New Zustand store for rate limit state
- src/hooks/useRateLimit.ts: Enable and integrate with new rate limiting
- src/hooks/useParlayGenerator.ts: Update to handle 20 request limit
- src/services/MockParlayService.ts: Bypass rate limiting for mock data
- src/services/RealParlayService.ts: Enforce frontend rate limiting
- src/components/auth/UserMenu.tsx: Clear rate limits on logout
- src/types/index.ts: Add rateLimitInfo to response interface

Fixes: Rate limit counter now properly decrements and resets on logout